### PR TITLE
Potential fix for code scanning alert no. 1: Exception text reinterpreted as HTML

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -424,14 +424,25 @@
         renderNews(data.articles || []);
         
       } catch (error) {
-        container.innerHTML = `
-          <div class="error">
-            <p>⚠️ Unable to load news</p>
-            <p style="margin-top: 0.5rem; font-size: 0.9rem;">
-              ${error.message}. Try refreshing or check back later.
-            </p>
-          </div>
-        `;
+        // Build error UI safely without interpreting error.message as HTML
+        container.innerHTML = '';
+
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'error';
+
+        const titleP = document.createElement('p');
+        titleP.textContent = '⚠️ Unable to load news';
+        errorDiv.appendChild(titleP);
+
+        const detailP = document.createElement('p');
+        detailP.style.marginTop = '0.5rem';
+        detailP.style.fontSize = '0.9rem';
+        // Use textContent so any characters in error.message are treated as text, not HTML
+        detailP.textContent = (error && error.message ? error.message : 'An unexpected error occurred') +
+          '. Try refreshing or check back later.';
+        errorDiv.appendChild(detailP);
+
+        container.appendChild(errorDiv);
       }
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/nirholas/free-crypto-news/security/code-scanning/1](https://github.com/nirholas/free-crypto-news/security/code-scanning/1)

In general, the problem is that exception text (`error.message`) is inserted into the DOM as HTML using `innerHTML` without escaping. The fix is to ensure that user‑influenced content is either (a) encoded before being placed into HTML, or (b) inserted using `textContent`/`innerText` so the browser does not interpret it as markup.

The best fix here without changing visible behavior much is to stop using a large HTML template literal for the error and instead construct the DOM nodes programmatically: set the container’s `innerHTML` to a static, trusted string, then set the error message via `textContent`. This keeps the same structure and styles while ensuring that `error.message` is treated as plain text and cannot inject HTML or scripts. Concretely, inside `loadNews`’s `catch` block in `docs/index.html` (around lines 426–434), replace the template literal assignment to `container.innerHTML` with code that:
1. Empties the container.
2. Creates a `<div>` with class `error`.
3. Adds a first `<p>` for the static "⚠️ Unable to load news" text.
4. Adds a second `<p>` for the explanatory text, and uses `textContent` for both the static prefix and the `error.message`, or constructs the full sentence via `textContent` so that no HTML parsing happens on user data.

No new imports or external libraries are required; everything can be implemented using standard DOM APIs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
