### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -48,7 +48,9 @@ interface PortfolioCoin {
 // Sanitize user-provided token query before using it in external requests
 function sanitizeSearchQuery(rawQuery: string): { value: string; isAddress: boolean } | null {
   const query = rawQuery.trim();
-  if (!query) {
+
+  // Reject empty or unreasonably long queries early to limit impact of tainted input
+  if (!query || query.length > 100) {
     return null;
   }
 
@@ -58,13 +60,17 @@ function sanitizeSearchQuery(rawQuery: string): { value: string; isAddress: bool
     return { value: query, isAddress: true };
   }
 
-  // For non-address searches, restrict to safe characters to avoid unexpected paths
-  const normalized = query
-    .toLowerCase()
-    .replace(/[^a-z0-9 _-]/g, '') // allow letters, digits, space, underscore, hyphen
-    .trim();
+  // For non-address searches, only allow expected token name/symbol characters.
+  // This prevents unexpected path/query manipulation in downstream requests.
+  const safePattern = /^[a-zA-Z0-9 _-]+$/;
+  if (!safePattern.test(query)) {
+    return null;
+  }
 
-  if (!normalized) {
+  const normalized = query.toLowerCase().trim();
+
+  // Require at least 2 characters after normalization to avoid meaningless lookups.
+  if (normalized.length < 2) {
     return null;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/nirholas/free-crypto-news/security/code-scanning/3](https://github.com/nirholas/free-crypto-news/security/code-scanning/3)

In general, SSRF mitigation requires ensuring that user-controlled data cannot arbitrarily influence the destination of server-side HTTP requests, especially the scheme, host, and path. For query strings and limited path segments, the usual approach is to (1) strictly validate the data against an allow-list of expected formats or values, and/or (2) transform it into a controlled internal representation (like mapping to known IDs) before using it in a URL.

In this specific code, the hostname is already fixed (`DEXSCREENER_API`), which is good, and we already have `sanitizeSearchQuery`. The remaining concern is that any arbitrary “safe-character” search string will be forwarded to DexScreener. We can improve this by adding additional validation in `sanitizeSearchQuery` to reject obviously malformed or unreasonably long queries, and by limiting the allowed character set and length for non-address searches even more strictly. This ensures the tainted data is normalized into a tightly constrained form before it ever reaches the URL construction. Since we must not alter external behavior significantly, the best fix is to harden `sanitizeSearchQuery`—which sits exactly on the tainted path—without changing how the rest of the code calls it.

Concretely:
- In `sanitizeSearchQuery` (lines 49–72), add:
  - A maximum length check on the trimmed input, so attackers cannot send huge or weird payloads.
  - A separate regex for non-address input that only allows typical token symbols/names (letters, digits, space, underscore, hyphen), and rejects anything else outright instead of just stripping it out.
  - A minimum length requirement for non-address searches (e.g., at least 2 characters).
- Keep the existing strict address pattern for contract-address searches.
- Ensure that if these validations fail, `sanitizeSearchQuery` returns `null`, causing `searchDexScreener` to short-circuit and not call `fetch` at all.

All changes are local to `src/app/api/portfolio/route.ts`, in the `sanitizeSearchQuery` function. No new methods or external imports are strictly required; we can implement all validation with built-in TypeScript/JavaScript features.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
